### PR TITLE
Enhance Inference with Gradient Freezing and Eval Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ nohup.out
 transformers/models/
 peft/models/
 peft/temp/
+hf_transformers/

--- a/.gitignore
+++ b/.gitignore
@@ -165,4 +165,3 @@ nohup.out
 transformers/models/
 peft/models/
 peft/temp/
-hf_transformers/

--- a/peft/peft_chatglm_inference.ipynb
+++ b/peft/peft_chatglm_inference.ipynb
@@ -56,7 +56,9 @@
     "base_model = AutoModel.from_pretrained(config.base_model_name_or_path,\n",
     "                                       quantization_config=q_config,\n",
     "                                       trust_remote_code=True,\n",
-    "                                       device_map='auto')"
+    "                                       device_map='auto')\n",
+    "base_model.requires_grad_(False)\n",
+    "base_model.eval()"
    ]
   },
   {


### PR DESCRIPTION
Introduced two updates to improve inference efficiency: 

1. Gradient Freezing (`base_model.requires_grad_(False)`) to prevent unnecessary computations by freezing gradients, reducing memory use and speeding up the model. 
2. Evaluation Mode (`base_model.eval()`) ensures the model operates in inference mode, disabling training-specific layers like Dropout for consistent results. 

These changes streamline performance and are essential for deploying the model in production environments.