### PR TITLE
添加关于新版本chatglm3-6b模型微调时需要更多显存的解析说明及其解决方法

### DIFF
--- a/chatglm/qlora_chatglm3.ipynb
+++ b/chatglm/qlora_chatglm3.ipynb
@@ -9,6 +9,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ff3a3927-59e9-4ea3-abcd-332147eac0ed",
+   "metadata": {},
+   "source": [
+    "<details>\n",
+    "<summary><b>注意：新版本的 chatglm3-6b 模型在微调过程中需要更多显存</b> (点击查看解决方法)</summary>\n",
+    "<table>\n",
+    "<tr><td><b>现象</b></td><td>如果在微调 chatglm3-6b 模型时，执行 trainer.train() 后瞬间出现 “OutOfMemoryError: CUDA out of memory.”（显存不足）错误，请考虑指定一个旧版本进行微调。</td></tr>\n",
+    "\n",
+    "<tr><td><b>原因</b></td><td>从2024年2月6日后发布的 chatglm3-6b 模型开始，调用 torch.utils.checkpoint.checkpoint() 方法时，use_reentrant 参数的默认值由原来的 True 改为 False。这导致在训练时保存更多的梯度参数以加快反向传播计算速度，同时占用更多显存。此外，新代码覆盖了基类 PreTrainedModel 中的 gradient_checkpointing_enable() 方法，导致无法通过梯度检查点来减少显存占用。有关详细的代码更改，请查看 <a href=\"https://huggingface.co/THUDM/chatglm3-6b/commit/37fe0008ee928af7f4e5e57693e8c7787d049af8\">Commit 37fe000</a>。</td></tr>\n",
+    "\n",
+    "<tr><td><b>方案</b></td><td>在加载 Tokenizer 和 Model 时，通过添加 revision 参数指定一个旧版本。示例代码如下：<br>\n",
+    "tokenizer = AutoTokenizer.from_pretrained(......, revision='b098244')<br>\n",
+    "model = AutoModel.from_pretrained(......, revision='b098244')</td></tr>\n",
+    "</table>\n",
+    "</details>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "f2386615-d1d6-40c9-a014-b2bce85838ab",
@@ -917,7 +936,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/chatglm/qlora_chatglm3_timestamp.ipynb
+++ b/chatglm/qlora_chatglm3_timestamp.ipynb
@@ -11,6 +11,33 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e63fd22b-b00f-4643-bc8a-a7cac180e943",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-08T16:19:38.797312Z",
+     "iopub.status.busy": "2024-02-08T16:19:38.796865Z",
+     "iopub.status.idle": "2024-02-08T16:19:38.815322Z",
+     "shell.execute_reply": "2024-02-08T16:19:38.813949Z",
+     "shell.execute_reply.started": "2024-02-08T16:19:38.797267Z"
+    }
+   },
+   "source": [
+    "<details>\n",
+    "<summary><b>注意：新版本的 chatglm3-6b 模型在微调过程中需要更多显存</b> (点击查看解决方法)</summary>\n",
+    "<table>\n",
+    "<tr><td><b>现象</b></td><td>如果在微调 chatglm3-6b 模型时，执行 trainer.train() 后瞬间出现 “OutOfMemoryError: CUDA out of memory.”（显存不足）错误，请考虑指定一个旧版本进行微调。</td></tr>\n",
+    "\n",
+    "<tr><td><b>原因</b></td><td>从2024年2月6日后发布的 chatglm3-6b 模型开始，调用 torch.utils.checkpoint.checkpoint() 方法时，use_reentrant 参数的默认值由原来的 True 改为 False。这导致在训练时保存更多的梯度参数以加快反向传播计算速度，同时占用更多显存。此外，新代码覆盖了基类 PreTrainedModel 中的 gradient_checkpointing_enable() 方法，导致无法通过梯度检查点来减少显存占用。有关详细的代码更改，请查看 <a href=\"https://huggingface.co/THUDM/chatglm3-6b/commit/37fe0008ee928af7f4e5e57693e8c7787d049af8\">Commit 37fe000</a>。</td></tr>\n",
+    "\n",
+    "<tr><td><b>方案</b></td><td>在加载 Tokenizer 和 Model 时，通过添加 revision 参数指定一个旧版本。示例代码如下：<br>\n",
+    "tokenizer = AutoTokenizer.from_pretrained(......, revision='b098244')<br>\n",
+    "model = AutoModel.from_pretrained(......, revision='b098244')</td></tr>\n",
+    "</table>\n",
+    "</details>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "f2386615-d1d6-40c9-a014-b2bce85838ab",
@@ -923,7 +950,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
对于新版本chatglm3-6b模型微调时需要更多显存的问题，我在两个notebook文件（qlora_chatglm3.ipynb 和 qlora_chatglm3_timestamp.ipynb）上添加了markdown格式的解析说明和解决方法。如果有问题，我可以再修改。